### PR TITLE
Update iot-hub-devguide-security.md

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-security.md
+++ b/articles/iot-hub/iot-hub-devguide-security.md
@@ -329,7 +329,7 @@ The [Azure IoT device SDK for .NET][lnk-client-sdk] (version 1.0.11+) supports t
 
 ### C\# Support
 The class **DeviceAuthenticationWithX509Certificate** supports the creation of 
- **DeviceClient** instances using an X.509 certificate.
+ **DeviceClient** instances using an X.509 certificate. The X.509 certificate must be in the PFX (also called PKCS #12) format which includes the private key. 
 
 Here is a sample code snippet:
 


### PR DESCRIPTION
Added a comment clarifying that when X.509 client certificates are used, it must be input in the PFX format including the private key.